### PR TITLE
Added Anonymization support, in case someone wants anonymized dumps directly.

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,12 @@
+# Example of new config
+jobs:
+- name: local-dump
+  dbdriver: postgresql
+  dbdsn: postgres://postgres:9520024606@localhost:5432/BTECH
+  gzip: false
+  anonymize:
+    enabled: true
+    strategy_file: strategy_file.yml
+  storage:
+    local:
+      - path: anonymized_dump.sql

--- a/config.yml
+++ b/config.yml
@@ -2,7 +2,7 @@
 jobs:
 - name: local-dump
   dbdriver: postgresql
-  dbdsn: postgres://postgres:9520024606@localhost:5432/BTECH
+  dbdsn: dbdsn: postgres://${DB_USER}:${DB_PASSWORD}@localhost:5432/BTECH
   gzip: false
   anonymize:
     enabled: true

--- a/config/job.go
+++ b/config/job.go
@@ -39,16 +39,21 @@ func (dump *Dump) Validate() error {
 	return errs
 }
 
+type AnonymizeConfig struct {
+	Enabled      bool   `yaml:"enabled"`
+	StrategyFile string `yaml:"strategy_file"`
+}
 type Job struct {
-	Name        string   `yaml:"name"`
-	DBDriver    string   `yaml:"dbdriver"`
-	DBDsn       string   `yaml:"dbdsn"`
-	Gzip        bool     `yaml:"gzip"`
-	Unique      bool     `yaml:"unique"`
-	SshHost     string   `yaml:"sshhost"`
-	SshUser     string   `yaml:"sshuser"`
-	SshKey      string   `yaml:"sshkey"`
-	DumpOptions []string `yaml:"options"`
+	Name        string           `yaml:"name"`
+	DBDriver    string           `yaml:"dbdriver"`
+	DBDsn       string           `yaml:"dbdsn"`
+	Gzip        bool             `yaml:"gzip"`
+	Unique      bool             `yaml:"unique"`
+	SshHost     string           `yaml:"sshhost"`
+	SshUser     string           `yaml:"sshuser"`
+	SshKey      string           `yaml:"sshkey"`
+	DumpOptions []string         `yaml:"options"`
+	Anonymize   *AnonymizeConfig `yaml:"anonymize"`
 	Storage     struct {
 		Local   []*local.Local     `yaml:"local"`
 		S3      []*s3.S3           `yaml:"s3"`

--- a/dumper/mysqldump.go
+++ b/dumper/mysqldump.go
@@ -88,7 +88,7 @@ func (mysql *MysqlDump) getExecDumpCommand() (string, []string, error) {
 	wholeCmd := "sh"
 	wholeArgs := []string{
 		"-c",
-		fmt.Sprintf("%s %s | pynonymizer --input - --strategy %s --output - --db-type postgres --db-user %s --db-host %s --db-password %s",
+		fmt.Sprintf("%s %s | pynonymizer --input - --strategy %s --output - --db-type mysql --db-user %s --db-host %s --db-password %s",
 			mysqldumpBinaryPath,
 			args,
 			mysql.strategyFile,
@@ -113,7 +113,7 @@ func (mysql *MysqlDump) getSshDumpCommand() (string, error) {
 		return baseCmd, nil
 	}
 
-	wholeCmd := fmt.Sprintf("%s | pynonymizer --input - --strategy %s --output - --db-type postgres --db-user %s --db-host %s --db-password %s",
+	wholeCmd := fmt.Sprintf("%s | pynonymizer --input - --strategy %s --output - --db-type mysql --db-user %s --db-host %s --db-password %s",
 		baseCmd,
 		mysql.strategyFile,
 		mysql.Username,

--- a/strategy_file.yml
+++ b/strategy_file.yml
@@ -1,0 +1,7 @@
+tables:
+  contact:  # table_name
+    columns:
+      email: email   # column_name
+  signup: truncate   # table_name
+      
+  


### PR DESCRIPTION
Hi,

I have added the support of anonymization for mysql and postgres databases. We just need to pass a flag of anonymization to identify when to anonymize and when to not to anonymize and the path to strategyfile which basically is required for anonymization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added data anonymization support for database dumps.
	- Introduced configuration options for anonymizing MySQL and PostgreSQL database exports.
	- Implemented strategy file for specifying data anonymization rules.

- **Configuration**
	- Added new job configuration example for local database dumps.
	- Expanded configuration schema to support anonymization settings.
	- New tables defined in strategy file for data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->