### PR TITLE
Use proper query to get MySQL binlog status according to different versions

### DIFF
--- a/binlog/binlogquerier.go
+++ b/binlog/binlogquerier.go
@@ -9,11 +9,11 @@ import (
 )
 
 const (
-	SHOW_LOG_BIN_QUERY          = "SHOW VARIABLES LIKE 'log_bin';"
-	SHOW_MASTER_STATUS_QUERY    = "SHOW MASTER STATUS;"
-	SHOW_BINLOG_STATUS_QUERY    = "SHOW BINARY LOG STATUS;"
-	SHOW_LOG_BIN_BASENAME_QUERY = "SHOW VARIABLES LIKE 'log_bin_basename';"
-	VERSION_QUERY               = "SELECT VERSION() AS mysql_version;"
+	ShowLogBinQuery         = "SHOW VARIABLES LIKE 'log_bin';"
+	ShowMasterStatusQuery   = "SHOW MASTER STATUS;"
+	ShowBinlogStatusQuery   = "SHOW BINARY LOG STATUS;"
+	ShowLogBinBasenameQuery = "SHOW VARIABLES LIKE 'log_bin_basename';"
+	VersionQuery            = "SELECT VERSION() AS mysql_version;"
 )
 
 type BinlogInfo struct {
@@ -33,22 +33,22 @@ func NewBinlogInfoQuerier(db *sql.DB) *binlogInfoQuerier {
 }
 
 func (b *binlogInfoQuerier) queryVersion() (*mysqlVersion, error) {
-	rows, err := b.db.Query(VERSION_QUERY)
+	rows, err := b.db.Query(VersionQuery)
 
 	if err != nil {
-		return nil, fmt.Errorf("fail to run query %s, error: %v", VERSION_QUERY, err)
+		return nil, fmt.Errorf("fail to run query %s, error: %v", VersionQuery, err)
 	}
 
 	defer func() {
 		if err := rows.Close(); err != nil {
-			slog.Error("fail to close database rows", slog.Any("error", err), slog.Any("query", VERSION_QUERY))
+			slog.Error("fail to close database rows", slog.Any("error", err), slog.Any("query", VersionQuery))
 		}
 	}()
 
 	var version string
 	if rows.Next() {
 		if err := rows.Scan(&version); err != nil {
-			return nil, fmt.Errorf("fail to scan database rows, query: %s, error: %v", VERSION_QUERY, err)
+			return nil, fmt.Errorf("fail to scan database rows, query: %s, error: %v", VersionQuery, err)
 		}
 	}
 
@@ -56,22 +56,22 @@ func (b *binlogInfoQuerier) queryVersion() (*mysqlVersion, error) {
 }
 
 func (b *binlogInfoQuerier) queryLogBin() error {
-	rows, err := b.db.Query(SHOW_LOG_BIN_QUERY)
+	rows, err := b.db.Query(ShowLogBinQuery)
 
 	if err != nil {
-		return fmt.Errorf("fail to run query %s, error: %v", SHOW_LOG_BIN_QUERY, err)
+		return fmt.Errorf("fail to run query %s, error: %v", ShowLogBinQuery, err)
 	}
 
 	defer func() {
 		if err := rows.Close(); err != nil {
-			slog.Error("fail to close database rows", slog.Any("error", err), slog.Any("query", SHOW_LOG_BIN_QUERY))
+			slog.Error("fail to close database rows", slog.Any("error", err), slog.Any("query", ShowLogBinQuery))
 		}
 	}()
 
 	var variableName, logBin string
 	if rows.Next() {
 		if err := rows.Scan(&variableName, &logBin); err != nil {
-			return fmt.Errorf("fail to scan database rows, query: %s, error: %v", SHOW_LOG_BIN_QUERY, err)
+			return fmt.Errorf("fail to scan database rows, query: %s, error: %v", ShowLogBinQuery, err)
 		}
 	}
 
@@ -83,14 +83,14 @@ func (b *binlogInfoQuerier) queryLogBin() error {
 }
 
 func (b *binlogInfoQuerier) queryLogBinBasename() (string, error) {
-	rows, err := b.db.Query(SHOW_LOG_BIN_BASENAME_QUERY)
+	rows, err := b.db.Query(ShowLogBinBasenameQuery)
 	if err != nil {
-		return "", fmt.Errorf("fail to run query %s, error: %v", SHOW_LOG_BIN_BASENAME_QUERY, err)
+		return "", fmt.Errorf("fail to run query %s, error: %v", ShowLogBinBasenameQuery, err)
 	}
 
 	defer func() {
 		if err := rows.Close(); err != nil {
-			slog.Error("fail to close database rows", slog.Any("error", err), slog.Any("query", SHOW_LOG_BIN_BASENAME_QUERY))
+			slog.Error("fail to close database rows", slog.Any("error", err), slog.Any("query", ShowLogBinBasenameQuery))
 		}
 	}()
 
@@ -98,7 +98,7 @@ func (b *binlogInfoQuerier) queryLogBinBasename() (string, error) {
 
 	if rows.Next() {
 		if err := rows.Scan(&variableName, &value); err != nil {
-			return "", fmt.Errorf("fail to scan database rows, query: %s, error: %v", SHOW_LOG_BIN_BASENAME_QUERY, err)
+			return "", fmt.Errorf("fail to scan database rows, query: %s, error: %v", ShowLogBinBasenameQuery, err)
 		}
 
 		return value, nil
@@ -117,10 +117,12 @@ func (b *binlogInfoQuerier) queryBinlogStatus() (string, error) {
 		return "", fmt.Errorf("fail to query MySQL version, error: %v", err)
 	}
 
-	showBinlogStatusQuery := SHOW_BINLOG_STATUS_QUERY
-
-	if version.major <= 8 && version.minor < 2 {
-		showBinlogStatusQuery = SHOW_MASTER_STATUS_QUERY
+	var showBinlogStatusQuery string
+	// use ShowMasterStatusQuery for all MySQL < 8.2
+	if version.major < 8 || (version.major == 8 && version.minor < 2) {
+		showBinlogStatusQuery = ShowMasterStatusQuery
+	} else {
+		showBinlogStatusQuery = ShowBinlogStatusQuery
 	}
 
 	rows, err := b.db.Query(showBinlogStatusQuery)

--- a/binlog/version.go
+++ b/binlog/version.go
@@ -1,6 +1,7 @@
 package binlog
 
 import (
+	"log/slog"
 	"strconv"
 	"strings"
 	"unicode"
@@ -12,6 +13,10 @@ type mysqlVersion struct {
 
 // It parses a MySQL version string (e.g., "8.0.34") into major, minor, and patch numbers.
 func splitServerVersion(version string) *mysqlVersion {
+	if version == "" {
+		return &mysqlVersion{major: 0, minor: 0, patch: 0}
+	}
+
 	parts := strings.Split(version, ".")
 
 	var major, minor, patch int
@@ -20,7 +25,7 @@ func splitServerVersion(version string) *mysqlVersion {
 		if i == 0 {
 			n, err := strconv.Atoi(v)
 			if err != nil {
-
+				slog.Info("failed to parse major version number", slog.String("version", version), slog.Any("error", err))
 				return &mysqlVersion{major: 0, minor: 0, patch: 0}
 			}
 

--- a/binlog/version.go
+++ b/binlog/version.go
@@ -1,0 +1,71 @@
+package binlog
+
+import (
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+type mysqlVersion struct {
+	major, minor, patch int
+}
+
+// It parses a MySQL version string (e.g., "8.0.34") into major, minor, and patch numbers.
+func splitServerVersion(version string) *mysqlVersion {
+	parts := strings.Split(version, ".")
+
+	var major, minor, patch int
+
+	for i, v := range parts {
+		if i == 0 {
+			n, err := strconv.Atoi(v)
+			if err != nil {
+
+				return &mysqlVersion{major: 0, minor: 0, patch: 0}
+			}
+
+			major = n
+		} else if i == 1 {
+			n, err := strconv.Atoi(v)
+
+			// if minor version string is not a number, then we try to extract number and ignore the patch part.
+			if err != nil {
+				minor = extractNumber(v)
+				return &mysqlVersion{
+					major: major,
+					minor: minor,
+					patch: 0,
+				}
+			}
+
+			minor = n
+		} else if i == 2 {
+			patch = extractNumber(v)
+		}
+	}
+
+	return &mysqlVersion{major, minor, patch}
+}
+
+func extractNumber(v string) int {
+	var numStr string
+
+	for _, ch := range v {
+		if unicode.IsNumber(ch) {
+			numStr += string(ch) // Collect digits
+		} else if len(numStr) > 0 {
+			break // Stop at the first non-digit after starting
+		}
+	}
+
+	if numStr == "" {
+		return 0
+	}
+
+	n, err := strconv.Atoi(numStr)
+	if err != nil {
+		return 0
+	}
+
+	return n
+}

--- a/binlog/version_test.go
+++ b/binlog/version_test.go
@@ -1,0 +1,26 @@
+package binlog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSplitServerVersion(t *testing.T) {
+	version := "8.0.22-0ubuntu0.20.04.2"
+
+	mysqlVersion := splitServerVersion(version)
+
+	assert := assert.New(t)
+	assert.Equal(8, mysqlVersion.major)
+	assert.Equal(0, mysqlVersion.minor)
+	assert.Equal(22, mysqlVersion.patch)
+
+	version = "8.4-0ubuntu0.20.04.2"
+
+	mysqlVersion = splitServerVersion(version)
+
+	assert.Equal(8, mysqlVersion.major)
+	assert.Equal(4, mysqlVersion.minor)
+	assert.Equal(0, mysqlVersion.patch)
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved detection and parsing of MySQL server version to enhance compatibility with different MySQL versions.
  - Dynamic selection of binlog status queries based on MySQL version for accurate status retrieval.
- **Bug Fixes**
  - Increased robustness in parsing MySQL version strings, including handling of non-numeric suffixes.
- **Tests**
  - Added and updated tests to cover MySQL version parsing and ensure reliable query behavior across various scenarios.
  - Enhanced test isolation with subtests and added version-dependent query logic coverage.
- **Refactor**
  - Improved test structure for better isolation and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->