### PR TITLE
Save binlog sync results in a log

### DIFF
--- a/binlog/binlogsyncer.go
+++ b/binlog/binlogsyncer.go
@@ -63,7 +63,7 @@ func (s *syncResult) save(dir string) error {
 		}
 	}()
 
-	data := append([]byte("\n"), encoded...)
+	data := append(encoded, []byte("\n")...)
 	_, err = syncFile.Write(data)
 
 	return err
@@ -174,9 +174,12 @@ func (b *BinlogSyncer) Sync(storage storage.Storage) error {
 		return syncError
 	}
 
-	err = newSyncResult(syncFiles, syncError).save(b.binlogDir)
+	saveErr := newSyncResult(syncFiles, syncError).save(b.binlogDir)
+	if saveErr != nil {
+		return errors.Join(syncError, saveErr)
+	}
 
-	return errors.Join(syncError, err)
+	return syncError
 }
 
 func NewBinlogSyncer(destinationPath string, checksum bool, saveLog bool, binlogInfo *BinlogInfo) *BinlogSyncer {

--- a/binlog/binlogsyncer.go
+++ b/binlog/binlogsyncer.go
@@ -1,23 +1,78 @@
 package binlog
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"sync"
+	"time"
 
 	"github.com/liweiyi88/onedump/filesync"
 	"github.com/liweiyi88/onedump/fileutil"
 	"github.com/liweiyi88/onedump/storage"
 )
 
-const MaxConcurrentSync = 10
+const (
+	MaxConcurrentSync = 10
+	SyncResultFile    = "onedump-binlog-sync.log"
+)
+
+type syncResult struct {
+	FinishAt time.Time `json:"finish_at"`
+	Files    []string  `json:"files"`
+	Ok       bool      `json:"ok"`
+	Error    string    `json:"error"`
+}
+
+func newSyncResult(files []string, err error) *syncResult {
+	var syncError string
+	var ok bool
+	if err != nil {
+		syncError = err.Error()
+	} else {
+		ok = true
+	}
+
+	return &syncResult{
+		Files:    files,
+		Error:    syncError,
+		FinishAt: time.Now().UTC(),
+		Ok:       ok,
+	}
+}
+
+func (s *syncResult) save(dir string) error {
+	encoded, err := json.Marshal(s)
+
+	if err != nil {
+		return fmt.Errorf("fail to encode sync result to json, error: %v", err)
+	}
+
+	syncFile, err := os.OpenFile(filepath.Join(dir, SyncResultFile), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("fail to open sync result file, error: %v", err)
+	}
+
+	defer func() {
+		if err := syncFile.Close(); err != nil {
+			slog.Error("fail to close sync file", slog.Any("filename", syncFile.Name()), slog.Any("error", err))
+		}
+	}()
+
+	data := append([]byte("\n"), encoded...)
+	_, err = syncFile.Write(data)
+
+	return err
+}
 
 type BinlogSyncer struct {
 	destinationPath string // storage folder
 	checksum        bool   // if save checksum and avoid re-transfer
+	saveLog         bool   // is save sync result in a log file
 	*BinlogInfo
 }
 
@@ -67,7 +122,27 @@ func (b *BinlogSyncer) Sync(storage storage.Storage) error {
 	errCh := make(chan error, len(files))
 	var wg sync.WaitGroup
 
-	for _, file := range files {
+	syncFiles := make([]string, 0)
+
+	// Filter out files that have been synced before.
+	// So the save log will persist proper file names.
+	if b.checksum {
+		for _, file := range files {
+			synced, err := filesync.HasSynced(file)
+
+			if err != nil {
+				return fmt.Errorf("fail to check if %s has been transfered, error: %v", file, err)
+			}
+
+			if !synced {
+				syncFiles = append(syncFiles, file)
+			}
+		}
+	} else {
+		syncFiles = files
+	}
+
+	for _, file := range syncFiles {
 		wg.Add(1)
 		limiter <- struct{}{}
 
@@ -78,7 +153,7 @@ func (b *BinlogSyncer) Sync(storage storage.Storage) error {
 			}()
 
 			if err := b.syncFile(file, storage); err != nil {
-				errCh <- err
+				errCh <- fmt.Errorf("fail to sync file: %s, error: %v", file, err)
 			}
 		}()
 	}
@@ -93,13 +168,22 @@ func (b *BinlogSyncer) Sync(storage storage.Storage) error {
 		allErrors = append(allErrors, err)
 	}
 
-	return errors.Join(allErrors...)
+	syncError := errors.Join(allErrors...)
+
+	if !b.saveLog {
+		return syncError
+	}
+
+	err = newSyncResult(syncFiles, syncError).save(b.binlogDir)
+
+	return errors.Join(syncError, err)
 }
 
-func NewBinlogSyncer(destinationPath string, checksum bool, binlogInfo *BinlogInfo) *BinlogSyncer {
+func NewBinlogSyncer(destinationPath string, checksum bool, saveLog bool, binlogInfo *BinlogInfo) *BinlogSyncer {
 	return &BinlogSyncer{
 		destinationPath,
 		checksum,
+		saveLog,
 		binlogInfo,
 	}
 }

--- a/binlog/binlogsyncer_test.go
+++ b/binlog/binlogsyncer_test.go
@@ -39,7 +39,7 @@ func TestBinlogSyncerSyncFile(t *testing.T) {
 			setupMock: func(ms *MockStorage) {
 				ms.On("Save", mock.Anything, mock.Anything).Return(nil)
 			},
-			checksum:    false,
+			checksum:    true,
 			expectError: false,
 		},
 		{
@@ -97,13 +97,15 @@ func TestBinlogSyncerSync(t *testing.T) {
 	tests := []struct {
 		name        string
 		saveLog     bool
+		checksum    bool
 		setupFiles  func() (string, error)
 		setupMock   func(*MockStorage, []string)
 		expectError bool
 	}{
 		{
-			name:    "successful sync of multiple files",
-			saveLog: true,
+			name:     "successful sync of multiple files",
+			saveLog:  true,
+			checksum: true,
 			setupFiles: func() (string, error) {
 				dir, err := os.MkdirTemp("", "binlogtest")
 				if err != nil {
@@ -122,15 +124,15 @@ func TestBinlogSyncerSync(t *testing.T) {
 			setupMock: func(ms *MockStorage, files []string) {
 				for range files {
 					ms.On("Save", mock.Anything, mock.AnythingOfType("storage.PathGeneratorFunc")).
-						Return(nil).
-						Once()
+						Return(nil)
 				}
 			},
 			expectError: false,
 		},
 		{
-			name:    "partial failure during sync",
-			saveLog: false,
+			name:     "partial failure during sync",
+			saveLog:  false,
+			checksum: false,
 			setupFiles: func() (string, error) {
 				dir, err := os.MkdirTemp("", "binlogtest")
 				if err != nil {
@@ -163,8 +165,9 @@ func TestBinlogSyncerSync(t *testing.T) {
 			expectError: true,
 		},
 		{
-			name:    "no files to sync",
-			saveLog: false,
+			name:     "no files to sync",
+			saveLog:  false,
+			checksum: true,
 			setupFiles: func() (string, error) {
 				dir, err := os.MkdirTemp("", "binlogtest")
 				if err != nil {
@@ -197,7 +200,7 @@ func TestBinlogSyncerSync(t *testing.T) {
 					binlogPrefix: "binlog",
 				},
 				destinationPath: "/test/destination",
-				checksum:        false,
+				checksum:        tt.checksum,
 				saveLog:         tt.saveLog,
 			}
 

--- a/cmd/binlog.go
+++ b/cmd/binlog.go
@@ -86,7 +86,7 @@ It requires the following environment variables:
 		}
 
 		s3 := s3.NewS3(s3Bucket, "", region, accessKeyId, secretAccessKey, sessionToken)
-		syncer := binlog.NewBinlogSyncer(s3Prefix, checksum, binlogInfo)
+		syncer := binlog.NewBinlogSyncer(s3Prefix, checksum, saveLog, binlogInfo)
 		return syncer.Sync(s3)
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,7 +24,7 @@ var limit int
 var mask, attach, verbose bool
 
 var sftpHost, sftpUser, sftpKey string
-var checksum bool
+var checksum, saveLog bool
 var sftpMaxAttempts int
 
 var rootCmd = &cobra.Command{
@@ -155,6 +155,7 @@ func init() {
 	binlogSyncS3Cmd.MarkFlagRequired("s3-bucket")
 	binlogSyncS3Cmd.MarkFlagRequired("s3-prefix")
 	binlogSyncS3Cmd.Flags().BoolVar(&checksum, "checksum", false, "whether to save the checksum to avoid repeating file transfers, default: false (optional)")
+	binlogSyncS3Cmd.Flags().BoolVar(&saveLog, "save-log", false, "whether to save the sync results in a log file, default: false (optional)")
 	binlogSyncS3Cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "prints additional debug information (optional)")
 
 	rootCmd.AddCommand(slowCmd)

--- a/docs/binlog/sync-s3.md
+++ b/docs/binlog/sync-s3.md
@@ -27,5 +27,13 @@ onedump binlog sync-s3 --s3-bucket="your-bucket" --s3-prefix="binlogs"
 onedump binlog sync-s3 --s3-bucket="your-bucket" --s3-prefix="binlogs" --checksum=true
 ```
 
+### Save sync results in a log
+
+The sync result log file is named `onedump-binlog-sync.log` and will be saved in the same directory as the binlogs.
+
+```
+onedump binlog sync-s3 --s3-bucket="your-bucket" --s3-prefix="binlogs" --save-log=true
+```
+
 #### View all available options
 Run `onedump binlog sync-s3 --help` see all available options.

--- a/filesync/filesync.go
+++ b/filesync/filesync.go
@@ -5,6 +5,16 @@ import (
 	"log/slog"
 )
 
+func HasSynced(filename string) (bool, error) {
+	synced, err := NewChecksum(filename).IsFileTransferred()
+
+	if err != nil {
+		return false, fmt.Errorf("fail to check if %s has been transferred, error: %v", filename, err)
+	}
+
+	return synced, nil
+}
+
 func SyncFile(filename string, checksum bool, syncFunc func() error) error {
 	fileChecksum := NewChecksum(filename)
 
@@ -29,8 +39,7 @@ func SyncFile(filename string, checksum bool, syncFunc func() error) error {
 	}
 
 	if checksum {
-		err := fileChecksum.SaveState()
-		if err != nil {
+		if err := fileChecksum.SaveState(); err != nil {
 			return fmt.Errorf("fail to save the checksum state file for %s, error: %v", filename, err)
 		}
 	}

--- a/filesync/filesync_test.go
+++ b/filesync/filesync_test.go
@@ -9,6 +9,25 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestHasSynced(t *testing.T) {
+	assert := assert.New(t)
+	filename := "test_checksum.txt"
+
+	if err := createTestFile(filename, "test content"); err != nil {
+		t.Error(err)
+	}
+
+	defer func() {
+		if err := os.Remove(filename); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	synced, err := HasSynced(filename)
+	assert.Nil(err)
+	assert.False(synced)
+}
+
 func TestSyncFile(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option to save sync results in a log file when syncing binlogs. Enable this with the new --save-log flag.
  - Log files are saved as onedump-binlog-sync.log in the binlog directory, capturing sync metadata and outcomes.
  - Introduced checksum verification to filter already synced files during binlog sync.

- **Documentation**
  - Updated user guide to describe the new --save-log option and its usage.

- **Bug Fixes**
  - Improved error reporting for file sync operations.

- **Tests**
  - Enhanced tests to verify log file creation, sync result saving, and checksum-based sync filtering.
  - Added tests for checking file sync status and saving sync results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->